### PR TITLE
Change pointer position on touch events.

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -140,6 +140,18 @@ export function run(program, runSettings, userData = {}) {
 			pointer.pressed = false
 			eventQueue.push('pointerUp')
 		})
+		
+		const touchHandler = e => {
+			const rect = settings.element.getBoundingClientRect()
+			pointer.x = e.touches[0].clientX - rect.left
+			pointer.y = e.touches[0].clientY - rect.top
+			eventQueue.push('pointerMove')
+		}
+
+		settings.element.addEventListener('touchmove', touchHandler)
+		settings.element.addEventListener('touchstart', touchHandler)
+		settings.element.addEventListener('touchend', touchHandler)
+
 
 		// CSS fix
 		settings.element.style.fontStrech = 'normal'


### PR DESCRIPTION
While the `pointerup` and `pointerdown` work with touch, `pointermoved` does not get called, which means cursor coordinates stay at `{x: 0, y: 0}` making it impossible to react on clicks on specific part of the canvas.
This commit adds listeners for `touchmove`, `touchstart` and `touchend` to update the cursor position.